### PR TITLE
added check to ensure attendance code is only valid on the same day

### DIFF
--- a/cyberham/backend.py
+++ b/cyberham/backend.py
@@ -3,6 +3,7 @@ import string
 
 from typing import Literal
 from datetime import datetime
+from pytz import timezone
 
 from cyberham import conn, c
 from cyberham.cyberclub_email import CyberClub, EmailPending
@@ -77,6 +78,14 @@ def attend_event(code: str, user_id: int, user_name: str):
     name, _, points, date, resources, attended_users = temp
     if f'{user_id}' in attended_users.split():
         return f"You have already redeemed {code}!", None
+
+    cst_tz = timezone('US/Central')
+
+    event_day = datetime.strptime(date, "%m/%d/%y").astimezone(cst_tz).date()
+    current_day = datetime.now().astimezone(cst_tz).date()
+    
+    if event_day != current_day:
+        return "You must redeem an event on the day it occurs!", None
 
     c.execute(
         "UPDATE users SET points = points + ? WHERE user_id = ?",


### PR DESCRIPTION
joseph made a good point that we can just get the time on the backend to check, no bot code change is necessary.

tested this locally from my pc, hopefully the ec2 instance being in a different timezone doesn't break it.