### PR TITLE
Create readonly database and api endpoint

### DIFF
--- a/cyberham/database/readonly.py
+++ b/cyberham/database/readonly.py
@@ -1,0 +1,31 @@
+import sqlite3
+from typing import Any
+
+
+class ReadonlyDB:
+    conn: sqlite3.Connection
+
+    def __init__(
+        self,
+        db_path: str,
+    ):
+        self.conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        self.conn.row_factory = sqlite3.Row
+
+    def close(self):
+        self.conn.close()
+
+    def execute(self, sql: str) -> dict[str, Any]:
+        cursor = self.conn.cursor()
+
+        try:
+            cursor.execute(sql)
+        except:
+            raise ValueError(f"Query failed or not allowed.")
+
+        if cursor.description is None:
+            return {"columns": [], "rows": []}
+
+        columns = [col[0] for col in cursor.description]
+        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+        return {"columns": columns, "rows": rows}

--- a/cyberham/database/typeddb.py
+++ b/cyberham/database/typeddb.py
@@ -1,4 +1,5 @@
 from cyberham.database.sqlite import SQLiteDB
+from cyberham.database.readonly import ReadonlyDB
 from cyberham.types import (
     TableName,
     User,
@@ -142,6 +143,7 @@ class TypedDB(Generic[T, PK]):
 
 
 db = SQLiteDB("cyberham.db")
+readonlydb = ReadonlyDB("cyberham.db")
 usersdb = TypedDB[User, tuple[str]](db, "users", ["user_id"])
 eventsdb = TypedDB[Event, tuple[str]](db, "events", ["code"])
 flaggeddb = TypedDB[Flagged, tuple[str]](db, "flagged", ["user_id"])


### PR DESCRIPTION
- Adds api endpoint and new class to make readonly queries to the database
- Matching frontend PR

Note:
- Extra diffs in dashboard.py due to it not being formatted properly (only real edits are the last few lines)