### PR TITLE
Add env development flag for admin permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ resumes/
 
 # Mac Specific Files
 .DS_Store
+CLAUDE.md

--- a/cyberham/__init__.py
+++ b/cyberham/__init__.py
@@ -75,6 +75,15 @@ setup_module_logging(__name__)
 
 # load various configs for export
 environment = config["environment"]
+is_development = environment == "dev"
+
+# Permission used for admin-only commands.
+# In dev, use manage_channels so the dev server can restrict access
+# without needing to give everyone manage_events.
+admin_permission: dict[str, bool] = (
+    {"manage_channels": True} if is_development else {"manage_events": True}
+)
+admin_permission_attr: str = "manage_channels" if is_development else "manage_events"
 website_url = config["website_url"]
 dashboard_config = config["dashboard"]
 discord_token: Any = config["discord"]["token"]

--- a/cyberham/bot/admin.py
+++ b/cyberham/bot/admin.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 
 import cyberham.backend.events as backend_events
 import cyberham.backend.users as backend_users
-from cyberham import guild_id
+from cyberham import guild_id, admin_permission
 from cyberham.bot.bot import Bot
 from cyberham.bot.ui import EditModal
 from cyberham.bot.utils import valid_guild
@@ -17,7 +17,7 @@ from cyberham.bot.utils import valid_guild
 def setup_commands(bot: Bot):
     command_tree = bot.command_tree
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="award", description="manually award points to a user", guilds=guild_id
     )
@@ -30,7 +30,7 @@ def setup_commands(bot: Bot):
         msg: str = backend_users.award(str(user.id), user.name, points)
         await interaction.response.send_message(msg)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="delete_all_events",
         description="delete all current discord events",
@@ -47,7 +47,7 @@ def setup_commands(bot: Bot):
         for event in interaction.guild.scheduled_events:
             await event.delete()
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.context_menu(name="Edit message", guilds=guild_id)
     async def edit_message(
         interaction: discord.Interaction, message: discord.Message
@@ -55,7 +55,7 @@ def setup_commands(bot: Bot):
         modal = EditModal(message)
         await interaction.response.send_modal(modal)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="send_editable_message",
         description="send a message that will be editable by user with permission configured in integrations",
@@ -65,7 +65,7 @@ def setup_commands(bot: Bot):
         modal = EditModal()
         await interaction.response.send_modal(modal)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="update_calendar_events",
         description="create discord events for google calendar events",

--- a/cyberham/bot/announcements.py
+++ b/cyberham/bot/announcements.py
@@ -5,7 +5,7 @@ import discord
 from discord import app_commands
 from datetime import datetime as dt, timedelta, date
 from calendar import day_name
-from cyberham import guild_id
+from cyberham import guild_id, admin_permission
 from cyberham.bot.bot import Bot
 from cyberham.bot.utils import valid_guild
 from cyberham.bot.constants import activity_group_channels
@@ -18,7 +18,7 @@ Events: TypeAlias = dict[int, dict[str, list[discord.ScheduledEvent]]]
 def setup_commands(bot: Bot):
     command_tree = bot.command_tree
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="generate_announcements",
         description="generates announcements boilerplate based on events",

--- a/cyberham/bot/events.py
+++ b/cyberham/bot/events.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 import discord
 from discord import app_commands
 import cyberham.backend.events as backend_events
-from cyberham import guild_id
+from cyberham import guild_id, admin_permission
 from cyberham.types import Category
 from cyberham.bot.bot import Bot
 from cyberham.bot.ui import AttendModal, PageDisplay
@@ -13,7 +13,7 @@ from cyberham.bot.utils import event_info, event_list_embed, handle_attend_respo
 def setup_commands(bot: Bot):
     command_tree = bot.command_tree
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="create",
         description="create an event and track its attendance",
@@ -58,7 +58,7 @@ def setup_commands(bot: Bot):
             return
         await handle_attend_response(interaction, code)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="find_event", description="get information on an event", guilds=guild_id
     )
@@ -77,7 +77,7 @@ def setup_commands(bot: Bot):
             )
             await interaction.response.send_message(embed=embed)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="event_list",
         description="get a list of all events created",

--- a/cyberham/bot/rsvp.py
+++ b/cyberham/bot/rsvp.py
@@ -7,12 +7,12 @@ import cyberham.backend.events as backend_events
 from cyberham.bot.bot import Bot
 from cyberham.bot.constants import activity_group_channels
 from cyberham.utils.date import validate_date
-from cyberham import environment
+from cyberham import environment, admin_permission
 
 def setup_commands(bot:Bot):
     command_tree=bot.command_tree
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="generate_rsvp_form",
         description="(unstable: breaks on server restart) generates RSVP poll for a given event code",
@@ -46,7 +46,7 @@ def setup_commands(bot:Bot):
         await channel.send(question, view=buttons)
         await interaction.response.send_message("RSVP question sent: "+question, ephemeral=True)
 
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @command_tree.command(
         name="count_rsvp",
         description="generates RSVP response count for a given event code",

--- a/cyberham/bot/users.py
+++ b/cyberham/bot/users.py
@@ -1,7 +1,7 @@
 import discord
 from discord import app_commands
 import cyberham.backend.register as backend_register
-from cyberham import guild_id
+from cyberham import guild_id, admin_permission, admin_permission_attr
 from cyberham.bot.bot import Bot
 from cyberham.bot.utils import valid_guild, user_profile_embed
 from typing import Any
@@ -67,7 +67,7 @@ def setup_commands(bot: Bot):
         description="get the attendance info for a specific member!",
         guilds=guild_id,
     )
-    @app_commands.default_permissions(manage_events=True)
+    @app_commands.default_permissions(**admin_permission)
     @app_commands.describe(member="The profile for which member")
     async def profile_member(interaction: discord.Interaction, member: discord.Member):
         await user_profile_embed(interaction, str(member.id))
@@ -98,7 +98,7 @@ def setup_commands(bot: Bot):
             isinstance(interaction.user, discord.Member)
             and interaction.user.resolved_permissions
         ):
-            perm: bool = interaction.user.resolved_permissions.manage_events
+            perm: bool = getattr(interaction.user.resolved_permissions, admin_permission_attr)
         else:
             perm = False
 


### PR DESCRIPTION
Summary: Adds a development env flag that uses manage_channels in dev instead of manage_events so the dev server can restrict access w/o granting everyone manage_events.

Closes #64 

Major changes:

- There's a couple new globals (is_development, admin_permission, admin_permission_attr) derived from existing env config

- All @app_commands.default_permissions(manage_events=True) decorators across bot command files now unpack 'admin_permission' instead of hardcoding the permission

- users.py resolved_permissions check uses getattr w/ admin_permission_attr instead of accessing manage_events

- All changes are just mechanical replacements of the hardcoded permission with the new global except for getattr which is necessary b/c attribute access can't be dynamic with dot notation

Non-obvious change:
The only non-obvious change is adding Claude.md to the gitignore which helps LLMs read through codebases faster locally

Testing:
pytest passes, behavior difference only noticable when environment = dev in config.toml, which switches required permission from manage_events to manage_channels. I didn't test it by signing in with Google, not 100% if I should sign in with another email besides the main cybersecurity club email given it sends out emails/looks at calendar

Impact awareness:
- No breaking changes in prod b/c it only affects dev
- Dev server members will need manage_channels instead of manage_events to use admin commands